### PR TITLE
Initialization error - cl deprecated

### DIFF
--- a/bespoke-themes.el
+++ b/bespoke-themes.el
@@ -36,6 +36,8 @@
 (unless (>= emacs-major-version 26)
   (error "Requires Emacs 26 or later"))
 
+(eval-when-compile (require 'cl-lib))
+
 ;;; Theme Options
 
 (defcustom bespoke-set-theme 'light


### PR DESCRIPTION
I already reported this on reddit - I have since then installed a new emacs  - emacs 28 with native compilation, but i still get the same behaviour. 
i have the use-package (straight: ... in an org-babel file and when i call it I get 

``` 
Warning (comp): bespoke-themes.el:67:11: Warning: Package cl is deprecated 
Warning (comp): /home/flo/.emacs.d/straight/build/bespoke-themes/bespoke-themes.el: Error: Symbol's value as variable is void for
```
trying to narrow it down, when I start `emacs -q` , only load `striaght.el` and then `use-package ` I can actually call 
``` elisp
(straight-use-package '(bespoke-themes :type git :host github :repo "mclear-tools/bespoke-themes" :branch "master"))
(require 'bespoke-modeline)

```
so only the modeline is loaded  (it is) and raw emacs is fine but when I add ´(require 'bespoke-themes)`

i got the similar to above 
``` elisp

Initialization fails with: "Symbol’s value as variable is void: for"
Package cl is deprecated
```

this seems not really an uncommon problem, cl is an old common-lisp library that's long deprecated but still included and one has to make sure its replacement 'cl-lib is activated for certain actions - you can google it, it's not like i'm a big expert here. 
with this basic addition, it works, what remains is ivy having it's own complaints but i'll make a new issue for that.