### PR TITLE
Fix typos in custom var definitions

### DIFF
--- a/bespoke-themes.el
+++ b/bespoke-themes.el
@@ -61,7 +61,13 @@ Initial value is 3"
   :group 'bespoke-themes
   :type 'integer)
 
-(defcustom bespoke-set-git-diff-modeline t
+(defcustom bespoke-set-mode-line-height 3
+  "Set the size of the mode line as an integer
+Initial value is 3"
+  :group 'bespoke-themes
+  :type 'integer)
+
+(defcustom bespoke-set-git-diff-mode-line t
   "If t then show diff lines in modeline"
   :group 'bespoke-themes
   :type 'boolean)


### PR DESCRIPTION
Fix typo in definition of bespoke-set-git-diff-mode-line.

Introduce missing bespoke-set-mode-line-height defcustom.