### PR TITLE
Set background for term-color-* faces to fix invisible text in vterm

### DIFF
--- a/bespoke-theme.el
+++ b/bespoke-theme.el
@@ -1059,14 +1059,14 @@ subtlety stand out from the mode line and other adjacent faces."
 
 ;;;;; Term
    `(term-bold                                    ((,class :foreground ,bespoke-strong :weight semi-bold)))
-   `(term-color-black                             ((,class :foregroud  ,bespoke-background)))
-   `(term-color-white                             ((,class :foreground ,bespoke-foreground)))
-   `(term-color-blue                              ((,class :foreground ,bespoke-blue)))
-   `(term-color-cyan                              ((,class :foreground ,bespoke-salient)))
-   `(term-color-green                             ((,class :foreground ,bespoke-green)))
-   `(term-color-magenta                           ((,class :foreground ,bespoke-popout)))
-   `(term-color-red                               ((,class :foreground ,bespoke-critical)))
-   `(term-color-yellow                            ((,class :foreground ,bespoke-yellow)))
+   `(term-color-black                             ((,class :foregroud  ,bespoke-background :background ,bespoke-background)))
+   `(term-color-white                             ((,class :foreground ,bespoke-foreground :background ,bespoke-foreground)))
+   `(term-color-blue                              ((,class :foreground ,bespoke-blue :background ,bespoke-blue)))
+   `(term-color-cyan                              ((,class :foreground ,bespoke-salient :background ,bespoke-salient)))
+   `(term-color-green                             ((,class :foreground ,bespoke-green :background ,bespoke-green)))
+   `(term-color-magenta                           ((,class :foreground ,bespoke-popout :background ,bespoke-popout)))
+   `(term-color-red                               ((,class :foreground ,bespoke-critical :background ,bespoke-critical)))
+   `(term-color-yellow                            ((,class :foreground ,bespoke-yellow :background ,bespoke-yellow)))
 
 ;;;;; Window Divs
    ;; divide windows more attractively


### PR DESCRIPTION
vterm.el [uses the background color](https://github.com/akermu/emacs-libvterm/blob/ed6e867cfab77c5a311a516d20af44f57526cfdc/vterm.el#L1506-L1509) of the `term-color-*` faces, which currently results in invisible text.

This PR sets the background to the same color as foreground to fix this. [Modus themes do that as well](https://gitlab.com/protesilaos/modus-themes/-/blob/505d7f279a4b8a7f9aa23283100e765b7cf472a5/modus-themes.el#L7335), so I assume it should cause no issues.

Current behavior:
![image](https://user-images.githubusercontent.com/5968483/159692021-60856331-9cc8-4af2-82cf-665509c675ea.png)

PR behavior:
![image](https://user-images.githubusercontent.com/5968483/159692125-bc069c2a-ff36-4feb-8972-d23ba8741f1c.png)
